### PR TITLE
optimize processTo by trim

### DIFF
--- a/core/src/main/java/com/citahub/cita/protocol/core/methods/request/Transaction.java
+++ b/core/src/main/java/com/citahub/cita/protocol/core/methods/request/Transaction.java
@@ -252,6 +252,6 @@ public class Transaction {
     }
 
     private static String processTo(String to) {
-        return !Strings.isEmpty(to) && Keys.verifyAddress(to) ? cleanHexPrefix(to).toLowerCase() : "";
+        return !Strings.isEmpty(to) && Keys.verifyAddress(to.trim()) ? cleanHexPrefix(to).toLowerCase() : "";
     }
 }


### PR DESCRIPTION
trim may be useful when the address contains spaces at the beginning or end